### PR TITLE
Bump Monero version to v0.17.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 # Alpine specifics from https://github.com/cornfeedhobo/docker-monero/blob/f96711415f97af1fc9364977d1f5f5ecd313aad0/Dockerfile
 
 # Set Monero branch or tag to build
-ARG MONERO_BRANCH=v0.17.3.0
+ARG MONERO_BRANCH=v0.17.3.2
 
 # Set the proper HEAD commit hash for the given branch/tag in MONERO_BRANCH
-ARG MONERO_COMMIT_HASH=ab18fea3500841fc312630d49ed6840b3aedb34d
+ARG MONERO_COMMIT_HASH=67e5ca9ad6f1c861ad315476a88f9d36c38a0abb
 
 # Select Alpine 3.15 for the build image base
 FROM alpine:3.15 as build

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ARG MONERO_BRANCH=v0.17.3.2
 
 # Set the proper HEAD commit hash for the given branch/tag in MONERO_BRANCH
-ARG MONERO_COMMIT_HASH=67e5ca9ad6f1c861ad315476a88f9d36c38a0abb
+ARG MONERO_COMMIT_HASH=424e4de16b98506170db7b0d7d87a79ccf541744
 
 # Select Alpine 3.15 for the build image base
 FROM alpine:3.15 as build

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://hub.docker.com/r/sethsimmons/simple-monerod
 
 ## Tags
 
-I will always release the latest Monero version under the `latest` tag as well as the version number tag (i.e. `v0.17.3.0`).
+I will always release the latest Monero version under the `latest` tag as well as the version number tag (i.e. `v0.17.3.2`).
 
 `latest`: The latest tagged version of Monero from https://github.com/monero-project/monero/tags, built on an Alpine base image  
 `alpine`: The latest tagged version of Monero from https://github.com/monero-project/monero/tags, built on an Alpine base image  

--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -1,5 +1,9 @@
 # From https://github.com/leonardochaia/docker-monerod/blob/master/src/Dockerfile
-ARG MONERO_BRANCH=v0.17.3.0
+# Set Monero branch or tag to build
+ARG MONERO_BRANCH=v0.17.3.2
+
+# Set the proper HEAD commit hash for the given branch/tag in MONERO_BRANCH
+ARG MONERO_COMMIT_HASH=67e5ca9ad6f1c861ad315476a88f9d36c38a0abb
 
 # Select Ubuntu 20.04LTS for the build image base
 FROM ubuntu:20.04 as build
@@ -34,6 +38,7 @@ WORKDIR /monero
 ARG MONERO_BRANCH
 RUN git clone --recursive --branch ${MONERO_BRANCH} \
     https://github.com/monero-project/monero . \
+    && test `git rev-parse HEAD` = ${MONERO_COMMIT_HASH} || exit 1 \
     && git submodule init && git submodule update \
     && mkdir -p build/release && cd build/release \
     # Create make build files manually for release-static-linux-x86_64

--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Set necessary args and environment variables for building Monero
+ARG MONERO_BRANCH
+ARG MONERO_COMMIT_HASH
 ARG NPROC
 ENV CFLAGS='-fPIC'
 ENV CXXFLAGS='-fPIC'
@@ -35,7 +37,6 @@ WORKDIR /monero
 
 # Git pull Monero source at specified tag/branch
 # Make static Monero binaries
-ARG MONERO_BRANCH
 RUN git clone --recursive --branch ${MONERO_BRANCH} \
     https://github.com/monero-project/monero . \
     && test `git rev-parse HEAD` = ${MONERO_COMMIT_HASH} || exit 1 \

--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -3,7 +3,7 @@
 ARG MONERO_BRANCH=v0.17.3.2
 
 # Set the proper HEAD commit hash for the given branch/tag in MONERO_BRANCH
-ARG MONERO_COMMIT_HASH=67e5ca9ad6f1c861ad315476a88f9d36c38a0abb
+ARG MONERO_COMMIT_HASH=424e4de16b98506170db7b0d7d87a79ccf541744
 
 # Select Ubuntu 20.04LTS for the build image base
 FROM ubuntu:20.04 as build


### PR DESCRIPTION
Pending Gitian reproducible builds being verified and completed, but image builds properly and should be all set once the release is ready.