### PR TITLE
Minimize refs fetched during 'git clone' for users with unstable connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,7 @@ WORKDIR /monero
 
 # Git pull Monero source at specified tag/branch and compile statically-linked monerod binary
 RUN set -ex && git clone --recursive --branch ${MONERO_BRANCH} \
+    --depth 1 --shallow-submodules \
     https://github.com/monero-project/monero . \
     && test `git rev-parse HEAD` = ${MONERO_COMMIT_HASH} || exit 1 \
     && case ${TARGETARCH:-amd64} in \

--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -38,6 +38,7 @@ WORKDIR /monero
 
 # Git pull Monero source at specified tag/branch and compile statically-linked monerod binary
 RUN set -ex && git clone --recursive --branch ${MONERO_BRANCH} \
+    --depth 1 --shallow-submodules \
     https://github.com/monero-project/monero . \
     && test `git rev-parse HEAD` = ${MONERO_COMMIT_HASH} || exit 1 \
     && mkdir -p build/release && cd build/release \


### PR DESCRIPTION
Perform a shallow clone of the monero repo & all submodules (only gets the refs required to build). Speeds up the clone & makes it more reliable for users with unstable connections (tor, vpn, or just a low-quality ISP).