### PR TITLE
Install and configure fixuid to enable running as a different UID:GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,7 +182,7 @@ ARG MONERO_HOME="/home/${MONERO_USER}/.bitmonero"
 VOLUME ${MONERO_HOME}
 
 # Add HEALTHCHECK against get_info endpoint
-HEALTHCHECK --interval=30s --timeout=5s CMD curl --fail http://localhost:18089/get_info || exit 1
+HEALTHCHECK --interval=30s --timeout=5s CMD curl --fail http://localhost:18081/get_info || exit 1
 
 # Start monerod with sane defaults that are overridden by user input (if applicable)
 CMD ["--rpc-restricted-bind-ip=0.0.0.0", "--rpc-restricted-bind-port=18089", "--no-igd", "--no-zmq", "--enable-dns-blocklist"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,6 @@ RUN set -ex && apk add --update --no-cache \
     protobuf-dev \
     rapidjson-dev \
     readline-dev \
-    unbound-dev \
     zeromq-dev
 
 # Set necessary args and environment variables for building Monero
@@ -92,6 +91,17 @@ ENV CFLAGS='-fPIC'
 ENV CXXFLAGS='-fPIC -DELPP_FEATURE_CRASH_LOG'
 ENV USE_SINGLE_BUILDDIR 1
 ENV BOOST_DEBUG         1
+
+# Build libunbound for static builds
+WORKDIR /tmp
+RUN wget https://www.nlnetlabs.nl/downloads/unbound/unbound-1.13.2.tar.gz && \
+    echo "0a13b547f3b92a026b5ebd0423f54c991e5718037fd9f72445817f6a040e1a83 unbound-1.13.2.tar.gz" | sha256sum -c && \
+    tar -xzf unbound-1.13.2.tar.gz && \
+    rm unbound-1.13.2.tar.gz && \
+    cd unbound-1.13.2 && \
+    ./configure --disable-shared --enable-static --without-pyunbound --with-libexpat=/usr --with-ssl=/usr --with-libevent=no --without-pythonmodule --disable-flto --with-pthreads --with-libunbound-only --with-pic && \
+    make -j${NPROC:-$(nproc)} && \
+    make -j${NPROC:-$(nproc)} install
 
 # Switch to Monero source directory
 WORKDIR /monero
@@ -126,7 +136,6 @@ RUN set -ex && apk add --update --no-cache \
     ncurses-libs \
     pcsc-lite-libs \
     readline \
-    unbound-dev \
     zeromq
 
 # Add user and setup directories for monerod

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,11 +94,11 @@ ENV BOOST_DEBUG         1
 
 # Build libunbound for static builds
 WORKDIR /tmp
-RUN wget https://www.nlnetlabs.nl/downloads/unbound/unbound-1.13.2.tar.gz && \
-    echo "0a13b547f3b92a026b5ebd0423f54c991e5718037fd9f72445817f6a040e1a83 unbound-1.13.2.tar.gz" | sha256sum -c && \
-    tar -xzf unbound-1.13.2.tar.gz && \
-    rm unbound-1.13.2.tar.gz && \
-    cd unbound-1.13.2 && \
+RUN wget https://www.nlnetlabs.nl/downloads/unbound/unbound-1.16.1.tar.gz && \
+    echo "2fe4762abccd564a0738d5d502f57ead273e681e92d50d7fba32d11103174e9a unbound-1.16.1.tar.gz" | sha256sum -c && \
+    tar -xzf unbound-1.16.1.tar.gz && \
+    rm unbound-1.16.1.tar.gz && \
+    cd unbound-1.16.1 && \
     ./configure --disable-shared --enable-static --without-pyunbound --with-libexpat=/usr --with-ssl=/usr --with-libevent=no --without-pythonmodule --disable-flto --with-pthreads --with-libunbound-only --with-pic && \
     make -j${NPROC:-$(nproc)} && \
     make -j${NPROC:-$(nproc)} install

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ ENV USE_SINGLE_BUILDDIR 1
 ENV BOOST_DEBUG         1
 
 # Build expat, a dependency for libunbound
-RUN set -ex && wget https://github.com/libexpat/libexpat/releases/download/R_2_4_1/expat-2.4.8.tar.bz2 && \
+RUN set -ex && wget https://github.com/libexpat/libexpat/releases/download/R_2_4_8/expat-2.4.8.tar.bz2 && \
     echo "a247a7f6bbb21cf2ca81ea4cbb916bfb9717ca523631675f99b3d4a5678dcd16  expat-2.4.8.tar.bz2" | sha256sum -c && \
     tar -xf expat-2.4.8.tar.bz2 && \
     rm expat-2.4.8.tar.bz2 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ ENV BOOST_DEBUG         1
 # Build libunbound for static builds
 WORKDIR /tmp
 RUN wget https://www.nlnetlabs.nl/downloads/unbound/unbound-1.16.1.tar.gz && \
-    echo "2fe4762abccd564a0738d5d502f57ead273e681e92d50d7fba32d11103174e9a unbound-1.16.1.tar.gz" | sha256sum -c && \
+    echo "2fe4762abccd564a0738d5d502f57ead273e681e92d50d7fba32d11103174e9a  unbound-1.16.1.tar.gz" | sha256sum -c && \
     tar -xzf unbound-1.16.1.tar.gz && \
     rm unbound-1.16.1.tar.gz && \
     cd unbound-1.16.1 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -177,10 +177,6 @@ EXPOSE 18080
 # Expose restricted RPC port
 EXPOSE 18089
 
-# Set volume where the blockchain data is stored
-ARG MONERO_HOME="/home/${MONERO_USER}/.bitmonero"
-VOLUME ${MONERO_HOME}
-
 # Add HEALTHCHECK against get_info endpoint
 HEALTHCHECK --interval=30s --timeout=5s CMD curl --fail http://localhost:18081/get_info || exit 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -155,7 +155,7 @@ RUN set -ex && adduser -Ds /bin/bash monero \
 
 # Copy and enable entrypoint script
 ADD entrypoint.sh /entrypoint.sh
-RUN ["chmod", "+x", "entrypoint.sh"]
+RUN set -ex && chmod +x entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 # Install and configure fixuid and switch to MONERO_USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,16 @@ ENV CXXFLAGS='-fPIC -DELPP_FEATURE_CRASH_LOG'
 ENV USE_SINGLE_BUILDDIR 1
 ENV BOOST_DEBUG         1
 
+# Build expat, a dependency for libunbound
+RUN wget https://github.com/libexpat/libexpat/releases/download/R_2_4_1/expat-2.4.1.tar.bz2 && \
+    echo "2f9b6a580b94577b150a7d5617ad4643a4301a6616ff459307df3e225bcfbf40  expat-2.4.1.tar.bz2" | sha256sum -c && \
+    tar -xf expat-2.4.1.tar.bz2 && \
+    rm expat-2.4.1.tar.bz2 && \
+    cd expat-2.4.1 && \
+    ./configure --enable-static --disable-shared --prefix=/usr && \
+    make -j${NPROC:-$(nproc)} && \
+    make -j${NPROC:-$(nproc)} install
+
 # Build libunbound for static builds
 WORKDIR /tmp
 RUN wget https://www.nlnetlabs.nl/downloads/unbound/unbound-1.16.1.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,18 +93,18 @@ ENV USE_SINGLE_BUILDDIR 1
 ENV BOOST_DEBUG         1
 
 # Build expat, a dependency for libunbound
-RUN wget https://github.com/libexpat/libexpat/releases/download/R_2_4_1/expat-2.4.1.tar.bz2 && \
-    echo "2f9b6a580b94577b150a7d5617ad4643a4301a6616ff459307df3e225bcfbf40  expat-2.4.1.tar.bz2" | sha256sum -c && \
-    tar -xf expat-2.4.1.tar.bz2 && \
-    rm expat-2.4.1.tar.bz2 && \
-    cd expat-2.4.1 && \
+RUN set -ex && wget https://github.com/libexpat/libexpat/releases/download/R_2_4_1/expat-2.4.8.tar.bz2 && \
+    echo "a247a7f6bbb21cf2ca81ea4cbb916bfb9717ca523631675f99b3d4a5678dcd16  expat-2.4.8.tar.bz2" | sha256sum -c && \
+    tar -xf expat-2.4.8.tar.bz2 && \
+    rm expat-2.4.8.tar.bz2 && \
+    cd expat-2.4.8 && \
     ./configure --enable-static --disable-shared --prefix=/usr && \
     make -j${NPROC:-$(nproc)} && \
     make -j${NPROC:-$(nproc)} install
 
 # Build libunbound for static builds
 WORKDIR /tmp
-RUN wget https://www.nlnetlabs.nl/downloads/unbound/unbound-1.16.1.tar.gz && \
+RUN set -ex && wget https://www.nlnetlabs.nl/downloads/unbound/unbound-1.16.1.tar.gz && \
     echo "2fe4762abccd564a0738d5d502f57ead273e681e92d50d7fba32d11103174e9a  unbound-1.16.1.tar.gz" | sha256sum -c && \
     tar -xzf unbound-1.16.1.tar.gz && \
     rm unbound-1.16.1.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ monerod Docker w/ public RPC (pruned):
 sudo docker run -d --restart unless-stopped --name="monerod" -v bitmonero:/home/monero/.bitmonero sethsimmons/simple-monerod:latest  --rpc-restricted-bind-ip=0.0.0.0 --rpc-restricted-bind-port=18089 --public-node --no-igd --no-zmq --enable-dns-blocklist --prune-blockchain
 ```
 
+## Running as a different user
+
+In situations where you need the daemon to be run as a different user, I have added [fixuid](https://github.com/boxboat/fixuid) to enable that. Much of the work for this was taken from [docker-monero](https://github.com/cornfeedhobo/docker-monero), and enables you to specify a new user/group in your `docker run` or `docker-compose.yml` file to run as a different user.
+
+- In `docker run` commands, you can specify the user like this: `--user 1000:1000`
+- In `docker-compose.yml` files, you can specify the user like this: `user: ${FIXUID:-1000}:${FIXGID:-1000}`
+
+A great use-case for this is running with the daemon's files stored on an NFS mount, or running monerod on a Synology NAS.
+
 ## Copyrights
 
 Code from this repository is released under MIT license. [Monero License](https://github.com/monero-project/monero/blob/master/LICENSE), [@leonardochaia License](https://github.com/leonardochaia/docker-monerod/blob/master/LICENSE)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,25 +1,16 @@
 #!/bin/ash
-# Credit for this entrypoint script goes to cornfeedhobo
+# Credit for the bulk of this entrypoint script goes to cornfeedhobo
 # Source is https://github.com/cornfeedhobo/docker-monero/blob/master/entrypoint.sh
 set -e
 
-# if thrown flags immediately,
-# assume they want to run the blockchain daemon
-if [ "${1:0:1}" = '-' ]; then
-	set -- monerod --non-interactive "$@"
-fi
+# Set require --non-interactive flag
+set -- monerod --non-interactive "$@"
 
-# if they are running the blockchain daemon,
-# make efficient use of memory
-if [ "$1" = 'monerod' ]; then
-	numa='numactl --interleave=all'
-	if $numa true &> /dev/null; then
-		set -- $numa "$@"
-	fi
-	# start the daemon using fixuid
-	# to adjust permissions if needed
-	exec fixuid -q "$@"
+# Configure NUMA if present for improved performance
+numa='numactl --interleave=all'
+if $numa true &> /dev/null; then
+	set -- $numa "$@"
 fi
-
-# otherwise, don't get in their way
-exec "$@"
+# Start the daemon using fixuid
+# to adjust permissions if needed
+exec fixuid -q "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/ash
+# Credit for this entrypoint script goes to cornfeedhobo
+# Source is https://github.com/cornfeedhobo/docker-monero/blob/master/entrypoint.sh
+set -e
+
+# if thrown flags immediately,
+# assume they want to run the blockchain daemon
+if [ "${1:0:1}" = '-' ]; then
+	set -- monerod --non-interactive "$@"
+fi
+
+# if they are running the blockchain daemon,
+# make efficient use of memory
+if [ "$1" = 'monerod' ]; then
+	numa='numactl --interleave=all'
+	if $numa true &> /dev/null; then
+		set -- $numa "$@"
+	fi
+	# start the daemon using fixuid
+	# to adjust permissions if needed
+	exec fixuid -q "$@"
+fi
+
+# otherwise, don't get in their way
+exec "$@"

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   monerod:
     image: sethsimmons/simple-monerod:latest
+    user: ${FIXUID:-1000}:${FIXGID:-1000}
     restart: unless-stopped
     container_name: monerod
     volumes:


### PR DESCRIPTION
Inspired by https://github.com/cornfeedhobo/docker-monero, this enables users to run monerod as a different user, making running on a NAS or in a unique environment more possible.