### PR TITLE
Update monero to v0.18.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 # Alpine specifics from https://github.com/cornfeedhobo/docker-monero/blob/f96711415f97af1fc9364977d1f5f5ecd313aad0/Dockerfile
 
 # Set Monero branch or tag to build
-ARG MONERO_BRANCH=v0.18.3.3
+ARG MONERO_BRANCH=v0.18.3.4
 
 # Set the proper HEAD commit hash for the given branch/tag in MONERO_BRANCH
-ARG MONERO_COMMIT_HASH=81d4db08eb75ce5392c65ca6571e7b08e41b7c95
+ARG MONERO_COMMIT_HASH=b089f9ee69924882c5d14dd1a6991deb05d9d1cd
 
 # Select Alpine 3 for the build image base
 FROM alpine:3 as build


### PR DESCRIPTION

This is the v0.18.3.4 release of the Monero software. This release removes support for locked transfers.

Some highlights of this release are:

- Remove support for locked transfers (#[9311](https://github.com/monero-project/monero/pull/9311))
- Daemon: skip privacy networks that don't have outgoing connections (#[9267](https://github.com/monero-project/monero/pull/9267))
- Daemon: prevent duplicate txs in fluff queue, fix unintended disconnections (#[9355](https://github.com/monero-project/monero/pull/9355))
- Daemon: ZMQ DaemonInfo bug fixes (#[9385](https://github.com/monero-project/monero/pull/9385))
- Wallet: fix stagenet wallet restore height estimate (#[9309](https://github.com/monero-project/monero/pull/9309))
- Wallet: add Ledger Flex support (#[9430](https://github.com/monero-project/monero/pull/9430))
- Fix a bug with log rotation mechanism (#[9396](https://github.com/monero-project/monero/pull/9396))

The complete list of changes is [available on GitHub](https://github.com/monero-project/monero/compare/v0.18.3.3...v0.18.3.4), along with [the source code](https://github.com/monero-project/monero/tree/v0.18.3.4).

# Contributors for this Release

This release was the direct result of 8 people who worked, largely unpaid and altruistically, to put out 39 commits containing 535 new lines of code. We'd like to thank them very much for their time and effort. In no particular order they are:

- 0xFFFC0000
- j-berman
- vtnerd
- tobtoht
- Boog900
- luigi1111
- selsta
- jeffro256