### PR TITLE
Bump monerod v0.18.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # renovate: datasource=github-releases depName=monero-project/monero
-ARG MONERO_BRANCH=v0.18.4.0
-ARG MONERO_COMMIT_HASH=f1311d4237404ab7da76241dbf10e92a65132cc4
+ARG MONERO_BRANCH=v0.18.4.1
+ARG MONERO_COMMIT_HASH=ec870e50706a29768a65f597155ed5c7ad7e6326
 
 # Select Alpine 3 for the build image base
 FROM alpine:3.22.1 AS build


### PR DESCRIPTION
This is the v0.18.4.1 release of the Monero software. This release contains bug fixes.

Some highlights of this release are:

- Wallet: fix stale multisig data after failed refresh (#[9911](https://github.com/monero-project/monero/pull/9911))
- Wallet: fix a bug when changing password (#[9945](https://github.com/monero-project/monero/pull/9945))
- Wallet: apply subaddress lookahead changes immediately (#[9954](https://github.com/monero-project/monero/pull/9954))
- Wallet respect `do-not-relay` in `sweep_single` (#[9978](https://github.com/monero-project/monero/pull/9978))
- Daemon: improve logic when connecting to a peer (#[9949](https://github.com/monero-project/monero/pull/9949))
- Daemon: add new dynamic fees to ZMQ (#[9958](https://github.com/monero-project/monero/pull/9958))
- RPC: fix edge case causing unresponsive wallet (#[9950](https://github.com/monero-project/monero/pull/9950))
- RPC: add `set_subaddresss_lookahead` endpoint (#[9954](https://github.com/monero-project/monero/pull/9954))
- Add safeguard for rare exception in TCP accept handler (#[9956](https://github.com/monero-project/monero/pull/9956))
- Minor bug fixes and improvements

The complete list of changes is [available on GitHub](https://github.com/monero-project/monero/compare/v0.18.4.0...v0.18.4.1), along with [the source code](https://github.com/monero-project/monero/tree/v0.18.4.1).