### PR TITLE
Add example nginx config

### DIFF
--- a/examples/nginx-rpc.conf
+++ b/examples/nginx-rpc.conf
@@ -1,0 +1,71 @@
+upstream monerorpc {
+        server 127.0.0.1:18081;
+        keepalive 64;
+}
+
+server {
+        listen 443 ssl;
+
+        # ssl config here
+        ssl_certificate     /etc/letsencrypt/live/your-monero-node/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/your-monero-node/privkey.pem;
+
+        server_name your-monero-node;
+
+        # cors config here for browsers
+
+        if ($request_method = 'OPTIONS') {
+                add_header Access-Control-Allow-Origin      '*';
+                add_header Access-Control-Allow-Credentials 'true';
+                add_header Access-Control-Allow-Methods     'GET, POST, OPTIONS';
+                add_header Access-Control-Allow-Headers     'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+                add_header Access-Control-Max-Age           1728000;
+                add_header Content-Type                     'text/plain charset=UTF-8';
+                add_header Content-Length                   0;
+                #add_header Strict-Transport-Security"max-age=63072000; includeSubdomains; preload";
+                return 204;
+        }
+        
+        if ($request_method = 'POST') {
+                add_header Access-Control-Allow-Origin      '*';
+                add_header Access-Control-Allow-Credentials 'true';
+                add_header Access-Control-Allow-Methods     'GET, POST, OPTIONS';
+                add_header Access-Control-Allow-Headers     'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+                #add_header Strict-Transport-Security"max-age=63072000; includeSubdomains; preload";
+        }
+        
+        if ($request_method = 'GET') {
+                add_header Access-Control-Allow-Origin      '*';
+                add_header Access-Control-Allow-Credentials 'true';
+                add_header Access-Control-Allow-Methods     'GET, POST, OPTIONS';
+                add_header Access-Control-Allow-Headers     'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+                #add_header Strict-Transport-Security"max-age=63072000; includeSubdomains; preload";
+        }
+        
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Credentials;
+        proxy_hide_header Access-Control-Allow-Methods;
+        proxy_hide_header Access-Control-Allow-Headers;
+        proxy_hide_header Access-Control-Max-Age;
+        proxy_hide_header X-Powered-By;
+
+        # monero rpc config here
+        location = / {
+                add_header Access-Control-Allow-Origin '*';
+                add_header Content-Type                'text/plain charset=UTF-8';
+
+                return 200 'Public Monero RPC';
+        }
+
+        location / {
+                proxy_buffering off;
+                proxy_request_buffering off;
+
+                # hide client's connection to prevent early close
+                proxy_set_header Connection "";
+                proxy_http_version 1.1;
+                proxy_read_timeout 600s;
+
+                proxy_pass http://monerorpc;
+        }
+}


### PR DESCRIPTION
Just that due to lack of guides to host a node with ssl wrappers like nginx most public nodes are hosted with either insecure http or ssl certificates with expired or invalid certificates

https://monero.fail/

Example node: https://xmr.0xrpc.io

Supporting nginx config would help hosting node with valid letsencrypt certificates