### PR TITLE
Bump monerod to v0.18.4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # renovate: datasource=github-releases depName=monero-project/monero
-ARG MONERO_BRANCH=v0.18.4.2
-ARG MONERO_COMMIT_HASH=d87edf57fcc4bc2279ad9d8a1db093805e6becd7
+ARG MONERO_BRANCH=v0.18.4.3
+ARG MONERO_COMMIT_HASH=7c6e84466a90f6701ebe09ff8f61ea8af3883181
 
 # Select Alpine 3 for the build image base
 FROM alpine:3.22.1 AS build


### PR DESCRIPTION
Some highlights of this release are:

- Wallet: increase batch subaddress creation limit to match RPC (https://github.com/monero-project/monero/pull/10098)
- Wallet: warn instead of throw when RingDB doesn't include spend (https://github.com/monero-project/monero/pull/10150)
- Daemon: improved peer selection with /24 subnet deduplication to disadvantage 'spy nodes' (https://github.com/monero-project/monero/pull/10113)
- Daemon: add max_block_count field to getblocks.bin RPC request (https://github.com/monero-project/monero/pull/9901)
- Daemon: send ZMQ miner notifications after txpool additions (https://github.com/monero-project/monero/pull/10104)
- Daemon: seed node maintenance (https://github.com/monero-project/monero/pull/10105, https://github.com/monero-project/monero/pull/10112, https://github.com/monero-project/monero/pull/10115)
- Daemon: fix on_getblockhash error return on too high height (https://github.com/monero-project/monero/pull/10125)
- RPC: allow creating more than 64 addresses at once (https://github.com/monero-project/monero/pull/10096)
- Fix logging deadlock (https://github.com/monero-project/monero/pull/10066)
- Minor bug fixes and improvements