### PR TITLE
Bump Monero version to v0.18.4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # renovate: datasource=github-releases depName=monero-project/monero
-ARG MONERO_BRANCH=v0.18.4.3
-ARG MONERO_COMMIT_HASH=7c6e84466a90f6701ebe09ff8f61ea8af3883181
+ARG MONERO_BRANCH=v0.18.4.4
+ARG MONERO_COMMIT_HASH=516e5355a103a2bf0b7e10328ebcaa2945019445
 
 # Select Alpine 3 for the build image base
 FROM alpine:3.22.2 AS build


### PR DESCRIPTION
This is the v0.18.4.4 release of the Monero software. This is a recommended release that fixes a bug with Ledger hardware wallet when rejecting secret view key export.

Some highlights of this release are:

- Ledger: make secret view key export mandatory (https://github.com/monero-project/monero/pull/10195)
- Wallet: identify spends in pool when scanning (https://github.com/monero-project/monero/pull/10153)
- Daemon: relay empty fluffy block on found block (https://github.com/monero-project/monero/pull/10206)
- Daemon: correct txpool weight miscalculation in edge case (https://github.com/monero-project/monero/pull/10204)
- Daemon: refine sync height selection logic (https://github.com/monero-project/monero/pull/10202)
- Additional logging deadlock fixes (https://github.com/monero-project/monero/pull/10194)
- Minor bug fixes and improvements

[Full release notes](https://github.com/monero-project/monero/releases/tag/v0.18.4.4)