### PR TITLE
Bump monerod to v0.18.4.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # renovate: datasource=github-releases depName=monero-project/monero
-ARG MONERO_BRANCH=v0.18.4.4
-ARG MONERO_COMMIT_HASH=516e5355a103a2bf0b7e10328ebcaa2945019445
+ARG MONERO_BRANCH=v0.18.4.5
+ARG MONERO_COMMIT_HASH=316a98b11ea29b65e61a42cfdc37f762736fd7c1
 
 # Select Alpine 3 for the build image base
 FROM alpine:3.23.2 AS build


### PR DESCRIPTION
This is the v0.18.4.5 release of the Monero software. This release fixes a bug with Ledger hardware wallet.

**Some highlights of this release are:**

- Ledger: fix Ledger Monero app crash (https://github.com/monero-project/monero/pull/10234)
- Ledger: add support for Ledger Nano Gen5 (https://github.com/monero-project/monero/pull/10243)
- Daemon: fix race condition causing dropped connections during sync (https://github.com/monero-project/monero/pull/10257)
- Wallet: fix edge case where key images remain marked unspent (https://github.com/monero-project/monero/pull/10255)
- Improve terminal color detection (https://github.com/monero-project/monero/pull/10268)
- Minor bug fixes and improvements

**Contributors for this Release**
This release was the direct result of 7 people who worked to put out 16 commits containing 76 new lines of code. We'd like to thank them very much for their time and effort. In no particular order, they are:

- tobtoht
- plowsof
- nahuhh
- selsta
- laanwj
- iamamyth
- j-berman