### PR TITLE
Update Monero version to v0.18.4.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # renovate: datasource=github-releases depName=monero-project/monero
-ARG MONERO_BRANCH=v0.18.4.5
-ARG MONERO_COMMIT_HASH=316a98b11ea29b65e61a42cfdc37f762736fd7c1
+ARG MONERO_BRANCH=v0.18.4.6
+ARG MONERO_COMMIT_HASH=dbcc7d212c094bd1a45f7291dbb99a4b4627a96d
 
 # Select Alpine 3 for the build image base
 FROM alpine:3.23.3 AS build


### PR DESCRIPTION
# Overview

This is the v0.18.4.6 release of the Monero software. This release contains bug fixes.

Some highlights of this release are:

- Daemon: fix bug in peer list filter (#10317)
- Daemon: p2p connection bug fixes (#10298)
- Multisig: fix key exchange failure in `monero-gen-trusted-multisig` (#10284)
- Minor bug fixes and improvements

# Contributors for this Release

This release was the direct result of 7 people who worked to put out 16 commits containing 197 new lines of code. We'd like to thank them very much for their time and effort. In no particular order, they are:

- tobtoht
- selsta
- binaryFate
- vtnerd
- woodser
- 0xFFFC0000
- j-berman