### PR TITLE
Harden CI: reliability smoke tests, least-privilege, build cache

### DIFF
--- a/.github/workflows/build-image-on-push.yml
+++ b/.github/workflows/build-image-on-push.yml
@@ -11,12 +11,25 @@ on:
     - 'Dockerfile'
   workflow_dispatch:
 
+# Least-privilege default token (this workflow only reads the repo and pulls cache)
+permissions:
+  contents: read
+
+# Cancel superseded runs for the same ref to save CI minutes
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GHCR_REPO: ghcr.io/${{ github.repository_owner }}/simple-monerod
 
 jobs:
   rebuild-container:
     name: "Build image with cache"
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -35,14 +48,13 @@ jobs:
         run: |
           echo "PLATFORM=linux/amd64" >> $GITHUB_ENV
           echo "DIGEST_NAME=amd64" >> $GITHUB_ENV
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0
-      -
-        name: Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v7
-      -
-        name: Test build of image
+        with:
+          persist-credentials: false
+      - name: Test build of image
         id: build
         uses: docker/build-push-action@v7.2.0
         with:
@@ -50,11 +62,36 @@ jobs:
           load: true
           platforms: ${{ env.PLATFORM }}
           tags: simple-monerod:testing
-          cache-from: type=registry,ref=${{ env.GHCR_REPO }}:latest
-      - 
-        name: Test-run image
+          cache-from: |
+            type=registry,ref=${{ env.GHCR_REPO }}:buildcache-${{ env.DIGEST_NAME }}
+            type=registry,ref=${{ env.GHCR_REPO }}:latest
+      - name: Verify reported version matches the pinned Monero tag
         run: |
-          docker run --rm simple-monerod:testing &
-          PID=$!
-          sleep 30
-          kill -SIGINT $PID # this will return a non-zero exit code if the container dies early on
+          set -euo pipefail
+          EXPECTED="$(awk -F= '/^ARG MONERO_BRANCH=/{print $2; exit}' Dockerfile)"
+          echo "Expecting monerod to report: ${EXPECTED}"
+          OUT="$(docker run --rm simple-monerod:testing --version || true)"
+          echo "Reported: ${OUT}"
+          echo "${OUT}" | grep -q "${EXPECTED}" \
+            || { echo "::error::monerod --version does not contain expected tag ${EXPECTED}"; exit 1; }
+      - name: Verify the container reaches a healthy state
+        run: |
+          set -uo pipefail
+          CID="$(docker run -d simple-monerod:testing)"
+          status="starting"
+          for i in $(seq 1 40); do
+            status="$(docker inspect -f '{{.State.Health.Status}}' "$CID" 2>/dev/null || echo gone)"
+            echo "attempt ${i}: health=${status}"
+            case "${status}" in
+              healthy) break ;;
+              unhealthy|gone)
+                echo "::error::container became ${status}"; docker logs "$CID" || true
+                docker rm -f "$CID" >/dev/null 2>&1 || true; exit 1 ;;
+            esac
+            sleep 5
+          done
+          if [ "${status}" != "healthy" ]; then
+            echo "::error::healthcheck did not pass within timeout"; docker logs "$CID" || true
+            docker rm -f "$CID" >/dev/null 2>&1 || true; exit 1
+          fi
+          docker rm -f "$CID" >/dev/null 2>&1 || true

--- a/.github/workflows/update-image-on-push.yml
+++ b/.github/workflows/update-image-on-push.yml
@@ -8,12 +8,26 @@ on:
     - 'Dockerfile'
   workflow_dispatch:
 
+# Least-privilege default; jobs that push opt into packages: write below
+permissions:
+  contents: read
+
+# Never run two prod pushes for the same ref concurrently (avoid racing the
+# manifest/`latest` tag); do not cancel an in-flight push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   GHCR_REPO: ghcr.io/${{ github.repository_owner }}/simple-monerod
 
 jobs:
   build:
     name: "Build container for multiple architectures and push by digest"
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -27,41 +41,82 @@ jobs:
         run: |
           echo "PLATFORM=linux/arm64" >> $GITHUB_ENV
           echo "DIGEST_NAME=arm64" >> $GITHUB_ENV
-      
+
       - name: Prepare platform matrix for amd64
         if: runner.arch == 'X64'
         run: |
           echo "PLATFORM=linux/amd64" >> $GITHUB_ENV
           echo "DIGEST_NAME=amd64" >> $GITHUB_ENV
-      
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: |
             ${{ env.GHCR_REPO }}
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0
-      
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Checkout repository
         uses: actions/checkout@v7
-      
-      - name: Build and and push by digest
+        with:
+          persist-credentials: false
+
+      - name: Build and push by digest
         uses: docker/build-push-action@v7.2.0
         id: build
         with:
           outputs: type=image,"name=${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
           platforms: ${{ env.PLATFORM }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.GHCR_REPO }}:latest
+          cache-from: |
+            type=registry,ref=${{ env.GHCR_REPO }}:buildcache-${{ env.DIGEST_NAME }}
+            type=registry,ref=${{ env.GHCR_REPO }}:latest
+          cache-to: type=registry,ref=${{ env.GHCR_REPO }}:buildcache-${{ env.DIGEST_NAME }},mode=max
+
+      # Smoke-test the exact artifact that was just pushed, BEFORE the merge job
+      # tags it `latest`. If this fails, the merge job (needs: build) never runs.
+      - name: Verify pushed image reports the pinned Monero tag
+        run: |
+          set -euo pipefail
+          EXPECTED="$(awk -F= '/^ARG MONERO_BRANCH=/{print $2; exit}' Dockerfile)"
+          REF="${GHCR_REPO}@${{ steps.build.outputs.digest }}"
+          echo "Expecting ${EXPECTED} from ${REF}"
+          OUT="$(docker run --rm "${REF}" --version || true)"
+          echo "Reported: ${OUT}"
+          echo "${OUT}" | grep -q "${EXPECTED}" \
+            || { echo "::error::pushed image version mismatch (expected ${EXPECTED})"; exit 1; }
+
+      - name: Verify pushed image reaches a healthy state
+        run: |
+          set -uo pipefail
+          REF="${GHCR_REPO}@${{ steps.build.outputs.digest }}"
+          CID="$(docker run -d "${REF}")"
+          status="starting"
+          for i in $(seq 1 40); do
+            status="$(docker inspect -f '{{.State.Health.Status}}' "$CID" 2>/dev/null || echo gone)"
+            echo "attempt ${i}: health=${status}"
+            case "${status}" in
+              healthy) break ;;
+              unhealthy|gone)
+                echo "::error::pushed image became ${status}"; docker logs "$CID" || true
+                docker rm -f "$CID" >/dev/null 2>&1 || true; exit 1 ;;
+            esac
+            sleep 5
+          done
+          if [ "${status}" != "healthy" ]; then
+            echo "::error::pushed image healthcheck did not pass within timeout"; docker logs "$CID" || true
+            docker rm -f "$CID" >/dev/null 2>&1 || true; exit 1
+          fi
+          docker rm -f "$CID" >/dev/null 2>&1 || true
 
       - name: Export digest
         run: |
@@ -79,9 +134,13 @@ jobs:
 
   merge:
     name: "Merge digests and push with proper tags"
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs:
       - build
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@v8
@@ -102,6 +161,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Get Monero release tag
         run: echo MONERO_TAG="$(awk -F '=' '/MONERO_BRANCH=/ {print $2}' Dockerfile)" >> $GITHUB_ENV


### PR DESCRIPTION
Improves the build/update GitHub Actions across three areas (one PR since all edit the same two workflow files; see commits/sections).

## Reliability — catch a bad revision before it's tagged `latest`
- **Smoke-test the pushed digest in the update workflow** before the `merge` job tags it. Previously the artifact shipped to prod was never run (the only test lived in the PR workflow). If the smoke test fails, `merge` (needs: build) never runs, so `latest` is not moved.
- **Version assertion:** the running `monerod --version` must contain the pinned `MONERO_BRANCH` tag — catches wrong/stale/mis-cached binaries.
- **Healthcheck gate:** poll Docker `HEALTHCHECK` to `healthy` (real RPC liveness) instead of `sleep 30`.

## Hardening
- Least-privilege `permissions:` (default `contents: read`; `packages: write` only on push/merge jobs — repo default token is currently write-all).
- `concurrency` groups (cancel superseded PR builds; serialize prod pushes so they don't race the `latest` tag).
- `persist-credentials: false` on checkout; `timeout-minutes` on jobs.

## Build cache
- `cache-to: type=registry,…:buildcache-<arch>,mode=max` so the from-source Monero compile is cached across runs (PR builds read it; only push builds write it).

Validated with `actionlint` (no errors). Not yet covered (per scope): SHA-pinning actions, provenance/SBOM, cosign signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)