### PR TITLE
bump monerod to v0.18.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # renovate: datasource=github-releases depName=monero-project/monero
-ARG MONERO_BRANCH=v0.18.5.0
-ARG MONERO_COMMIT_HASH=3ca4c30f73fe22d16a46cfba122556437da3618d
+ARG MONERO_BRANCH=v0.18.5.1
+ARG MONERO_COMMIT_HASH=4f92268d7c16741cfb41e5bbe2aa46cc260a9ea5
 
 # Select Alpine 3 for the build image base
 FROM alpine:3.24.1 AS build


### PR DESCRIPTION
## Overview

This is the v0.18.5.1 release of the Monero software. This recommended release includes a large number of bug fixes.

Some highlights of this release are:

- Daemon: display IPv6 connections ([#10611](https://github.com/monero-project/monero/pull/10611))
- Daemon: fix slow shutdown with Tor/I2P enabled ([#10698](https://github.com/monero-project/monero/pull/10698))
- Daemon: avoid unsafe pidfile truncation ([#10608](https://github.com/monero-project/monero/pull/10608))
- Daemon: use latest hard fork block for approximate blockchain height ([#10580](https://github.com/monero-project/monero/pull/10580))
- Daemon: restrict `get_alt_blocks_hashes` RPC ([#10610](https://github.com/monero-project/monero/pull/10610))
- Daemon: fix wrong `block_weight` in `handle_get_objects` ([#10715](https://github.com/monero-project/monero/pull/10715))
- Daemon: improve incoming block scan table handling ([#10838](https://github.com/monero-project/monero/pull/10838))
- Daemon: restore safe sync mode when target height drops ([#10598](https://github.com/monero-project/monero/pull/10598))
- Daemon: canonicalize Tor and I2P hostnames ([#10638](https://github.com/monero-project/monero/pull/10638), [#10704](https://github.com/monero-project/monero/pull/10704))
- Daemon: fix dangling iterator in remote host checks ([#10649](https://github.com/monero-project/monero/pull/10649))
- Daemon: improve duplicate transaction handling in `handle_notify_new_transactions` ([#10836](https://github.com/monero-project/monero/pull/10836))
- Daemon: fix use-after-free in txpool prune ([#10710](https://github.com/monero-project/monero/pull/10710))
- ZMQ: cap aggregate receive size ([#10757](https://github.com/monero-project/monero/pull/10757))
- ZMQ: apply restricted-mode privacy filtering to `get_transaction_pool` ([#10543](https://github.com/monero-project/monero/pull/10543))
- Wallet: store multisig nonce erasure before returning signed txset ([#10754](https://github.com/monero-project/monero/pull/10754))
- Wallet: hardening against malicious remote nodes ([#10773](https://github.com/monero-project/monero/pull/10773), [#10776](https://github.com/monero-project/monero/pull/10776), [#10774](https://github.com/monero-project/monero/pull/10774))
- Wallet RPC: add missing trusted daemon check to `rescan_spent` ([#10542](https://github.com/monero-project/monero/pull/10542))
- Wallet RPC: fix `describe_transfer` source entry ([#10592](https://github.com/monero-project/monero/pull/10592))
- Wallet RPC: preserve payment ID when editing address book ([#10590](https://github.com/monero-project/monero/pull/10590))
- Wallet RPC: remove unused `finalize_multisig` endpoint ([#10615](https://github.com/monero-project/monero/pull/10615))
- Miner: fix thread 0 always using secure JIT ([#10743](https://github.com/monero-project/monero/pull/10743))
- RandomX: update to v1.2.2 ([#10571](https://github.com/monero-project/monero/pull/10571))
- Fix memory leak with readline ([#10568](https://github.com/monero-project/monero/pull/10568))
- Fix memory leak with RandomX integration on Windows ([#10546](https://github.com/monero-project/monero/pull/10546))
- Various bug fixes and improvements

## Contributors for this Release

This release was the direct result of 13 people who worked to put out 102 commits containing 1094 new lines of code. We'd like to thank them very much for their time and effort. In no particular order, they are:

- jeffro256
- tobtoht
- SNeedlewoods
- selsta
- greatjourney589
- iuyua9
- glv2
- alhudz
- nahuhh
- woodser
- ComputeryPony
- SChernykh
- j-berman