### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-image-on-push.yml
+++ b/.github/workflows/build-image-on-push.yml
@@ -49,14 +49,14 @@ jobs:
           echo "PLATFORM=linux/amd64" >> $GITHUB_ENV
           echo "DIGEST_NAME=amd64" >> $GITHUB_ENV
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.2.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Test build of image
         id: build
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: false
           load: true

--- a/.github/workflows/update-image-on-push.yml
+++ b/.github/workflows/update-image-on-push.yml
@@ -50,28 +50,28 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ env.GHCR_REPO }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.2.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Build and push by digest
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: build
         with:
           outputs: type=image,"name=${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
@@ -125,7 +125,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ env.DIGEST_NAME }}
           path: ${{ runner.temp }}/digests/*
@@ -143,24 +143,24 @@ jobs:
       packages: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Login to GHCR
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.2.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -169,7 +169,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ env.GHCR_REPO }}


### PR DESCRIPTION
### Summary
Pins all 14 `uses:` references across both workflow files to exact 40-character commit SHAs with semver version comments, protecting the CI supply chain against tag-tampering attacks.

### Why
GitHub Action tags (`@v4`, `@v7`) are mutable — a compromised action repo can force-push a malicious version under the same tag. Pinning to commit SHAs ensures CI runs an immutable, auditable version of every action.

### Changes
| Action | Old ref | New tag | SHA |
|---|---|---|---|
| `docker/setup-buildx-action` | `@v4.2.0` | `v4.2.0` | `bb05f3f` |
| `actions/checkout` | `@v7` | `v7.0.0` | `9c091bb` |
| `docker/build-push-action` | `@v7.3.0` | `v7.3.0` | `53b7df9` |
| `docker/metadata-action` | `@v6` | `v6.2.0` | `dc80280` |
| `docker/login-action` | `@v4.4.0` | `v4.4.0` | `af1e73f` |
| `actions/upload-artifact` | `@v7` | `v7.0.1` | `043fb46` |
| `actions/download-artifact` | `@v8` | `v8.0.1` | `3e5f45b` |

No breaking changes detected — all actions stayed within the same major version.

### Renovate compatibility
Renovate is already active on this repo and managing GitHub Actions. Renovate natively understands the `@<sha> # <tag>` format and will automatically update both the SHA and the trailing version comment when new releases are published. No changes to `renovate.json` were needed.