### PR TITLE
Add helpers:pinGitHubActionDigests to Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended",
     "docker:enableMajor",
+    "helpers:pinGitHubActionDigests",
     "mergeConfidence:all-badges",
     ":disableRateLimiting",
     ":semanticCommits"


### PR DESCRIPTION
### Summary
Adds the `helpers:pinGitHubActionDigests` preset to `.github/renovate.json`.

### Why
#235 pins all existing workflow actions to commit SHAs, but nothing enforces that guarantee going forward — an action added later with a floating tag (`@v4`) would silently reintroduce the tag-tampering exposure. With this preset, Renovate automatically opens a PR pinning any unpinned `uses:` reference to its commit SHA (with the usual `# vX.Y.Z` comment), so the pinning established in #235 doesn't erode over time.

No effect on already-pinned actions or on any other Renovate behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)