### PR TITLE
feat: verify SHA256 checksum of fixuid release tarball

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -178,13 +178,20 @@ ENTRYPOINT [ "/entrypoint.sh" ]
 # Install and configure fixuid and switch to MONERO_USER
 ARG MONERO_USER="monero"
 ARG TARGETARCH
+# Checksums must be updated manually when bumping FIXUID_VERSION (upstream publishes no checksum file)
+ARG FIXUID_AMD64_CHECKSUM=8c47f64ec4eec60e79871796ea4097ead919f7fcdedace766da9510b78c5fa14
+ARG FIXUID_ARM64_CHECKSUM=827e0b480c38470b5defb84343be7bb4e85b9efcbf3780ac779374e8b040a969
 # renovate: datasource=github-releases depName=boxboat/fixuid
 ARG FIXUID_VERSION=0.6.0
 RUN set -ex && case ${TARGETARCH:-amd64} in \
-        "arm64") curl -SsL https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-arm64.tar.gz | tar -C /usr/local/bin -xzf - ;; \
-        "amd64") curl -SsL https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - ;; \
+        "arm64") FIXUID_ARCH="arm64"; FIXUID_CHECKSUM="${FIXUID_ARM64_CHECKSUM}" ;; \
+        "amd64") FIXUID_ARCH="amd64"; FIXUID_CHECKSUM="${FIXUID_AMD64_CHECKSUM}" ;; \
         *) echo "Dockerfile does not support this platform"; exit 1 ;; \
     esac && \
+    curl -SsL -o /tmp/fixuid.tar.gz "https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-${FIXUID_ARCH}.tar.gz" && \
+    echo "${FIXUID_CHECKSUM}  /tmp/fixuid.tar.gz" | sha256sum -c && \
+    tar -C /usr/local/bin -xzf /tmp/fixuid.tar.gz && \
+    rm /tmp/fixuid.tar.gz && \
     chown root:root /usr/local/bin/fixuid && \
     chmod 4755 /usr/local/bin/fixuid && \
     mkdir -p /etc/fixuid && \


### PR DESCRIPTION
## Summary

The fixuid tarball was previously piped straight from GitHub releases into `tar` with no integrity verification, then installed **setuid root** (`chmod 4755`). A compromised release asset, hijacked upstream repo, or MITM'd download would have become a root-privilege binary in every image build. Unlike expat and libunbound in the same Dockerfile, fixuid had no checksum verification.

This PR downloads the tarball to a file and verifies a pinned per-arch SHA256 checksum before extraction, matching the existing expat/libunbound pattern.

## Checksum provenance

Upstream publishes no checksum file, so the hashes were computed from fresh downloads and cross-checked against GitHub code search: 13 independent public repos pin the identical hashes for both arches (e.g. `luislavena/hydrofoil-crystal`, `luislavena/hydrofoil-php`), consistent with what the ecosystem has observed since the 2023 release.

## Renovate interplay

The checksum ARGs are placed *before* the `# renovate:` comment so the custom regex manager doesn't capture one as `currentDigest` — the `github-releases` datasource can't resolve digests without an upstream checksum file, which would break version-bump PRs. Tradeoff: when Renovate bumps `FIXUID_VERSION`, the build fails until the checksums are updated by hand. That is fail-closed by design and noted in a comment above the ARGs.

## Verification

- Built the fixuid stage for both `linux/amd64` and `linux/arm64` — both pass
- In the built image, `fixuid` is `-rwsr-xr-x root:root` and correctly remaps a mismatched runtime UID (1005) to `monero`
- With a deliberately wrong checksum, the build aborts at `sha256sum -c` **before extraction**

🤖 Generated with [Claude Code](https://claude.com/claude-code)