### PR TITLE
fix: make healthcheck honor --rpc-login credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -175,6 +175,9 @@ RUN set -ex && adduser -Ds /bin/ash monero \
 COPY --chmod=0755 entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]
 
+# Copy healthcheck script
+COPY --chmod=0755 healthcheck.sh /healthcheck.sh
+
 # Install and configure fixuid and switch to MONERO_USER
 ARG MONERO_USER="monero"
 ARG TARGETARCH
@@ -209,8 +212,8 @@ EXPOSE 18080
 # Expose restricted RPC port
 EXPOSE 18089
 
-# Add HEALTHCHECK against get_height endpoint
-HEALTHCHECK --interval=30s --timeout=5s CMD curl --fail http://127.0.0.1:18081/get_height || exit 1
+# Add HEALTHCHECK against get_height endpoint, honoring --rpc-login credentials if set
+HEALTHCHECK --interval=30s --timeout=5s CMD /healthcheck.sh || exit 1
 
 # Start monerod with sane defaults that are overridden by user input (if applicable)
 CMD ["--rpc-restricted-bind-ip=0.0.0.0", "--rpc-restricted-bind-port=18089", "--no-igd", "--no-zmq", "--enable-dns-blocklist", "--ban-list=/home/monero/ban_list.txt"]

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Healthcheck for monerod that supports --rpc-login
+# The RPC port and credentials are read from the running daemon's command
+# line (PID 1), so the check automatically follows the container's
+# configuration without any compose-file overrides.
+set -eu
+
+# Print the value of a daemon argument, handling both "--flag=value" and
+# "--flag value" forms. Prints nothing if the flag is absent.
+get_arg() {
+    tr '\0' '\n' < /proc/1/cmdline | awk -v flag="$1" '
+        prev == flag { print; exit }
+        index($0, flag "=") == 1 { print substr($0, length(flag) + 2); exit }
+        { prev = $0 }
+    '
+}
+
+RPC_LOGIN="$(get_arg --rpc-login)"
+RPC_PORT="$(get_arg --rpc-bind-port)"
+RPC_URL="http://127.0.0.1:${RPC_PORT:-18081}/get_height"
+
+if [ -n "${RPC_LOGIN}" ]; then
+    curl --fail --silent --digest --user "${RPC_LOGIN}" "${RPC_URL}"
+else
+    # Credentials may still be set via --config-file, which cannot be read
+    # here; a 401 response proves the RPC server is alive regardless.
+    status="$(curl --silent --output /dev/null --write-out '%{http_code}' "${RPC_URL}")"
+    [ "${status}" = "200" ] || [ "${status}" = "401" ]
+fi


### PR DESCRIPTION
## Summary

Fixes #205.

The baked-in `HEALTHCHECK` ran a plain `curl --fail` against `/get_height`, so any container started with `--rpc-login` got a 401 and was permanently reported unhealthy even though the node was fine.

This replaces the inline curl with a `healthcheck.sh` that configures itself from the running daemon:

- Reads `/proc/1/cmdline` (the entrypoint `exec`s monerod via fixuid, so PID 1 is the daemon itself) to find `--rpc-login`, handling both `--rpc-login=user:pass` and `--rpc-login user:pass` forms, and authenticates with `curl --digest` when present
- Honors a custom `--rpc-bind-port` the same way (default 18081)
- When credentials are supplied via `--config-file` (not readable from the command line), a 401 response is treated as alive — it proves the RPC server is up and responding, which is exactly the case failing today

No compose-file overrides needed; existing deployments keep working unchanged.

## Verification

Tested against the published `ghcr.io/sethforprivacy/simple-monerod:latest` image (real monerod, script mounted in):

| Scenario | Old check | New check |
|---|---|---|
| `--rpc-login=test:pass123` | ❌ curl exit 22 (401) — reproduces the issue | ✅ digest auth, real `get_height` JSON |
| `--rpc-login test:pass123` (space form) | — | ✅ |
| no login, `--rpc-bind-port=28081` | ❌ (hardcoded port) | ✅ |
| wrong credentials | — | ❌ fails as it should (non-vacuous) |
| RPC unreachable | ❌ | ❌ fails as it should |

A companion PR adds an equivalent healthcheck (via `json_rpc` `get_version`) to simple-monero-wallet-rpc-docker, which currently ships no healthcheck at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)